### PR TITLE
Exclude orphan end from Lua syntax. Create new region for orphan end

### DIFF
--- a/syntax/etlua.vim
+++ b/syntax/etlua.vim
@@ -1,7 +1,7 @@
 " Language:     etlua
 " Maintainer:   VaiN474 (https://github.com/VaiN474)
 " License:      MIT
-" Last Change:  Aug 24 2017
+" Last Change:  Aug 06 2018
 
 if !exists("main_syntax")
   let main_syntax = 'html'
@@ -19,7 +19,9 @@ if exists('b:current_syntax')
   unlet b:current_syntax
 endif
 syntax include @Lua syntax/lua.vim
-syntax region luaEmbedded matchgroup=SpecialComment start=+<%+ end=+%>+ keepend containedin=@HTML contains=@Lua
+syntax region luaEmbedded matchgroup=SpecialComment start=+\(<%\)\(\s*end\)\@!+ end=+%>+ keepend containedin=@HTML contains=@Lua
+syn region LuaOrphanEnd matchgroup=SpecialComment start=+\(<%\)\(\s*end\s*%>\)\@=+ end=+\(<%\s*end\s*\)\@<=\(%>\)+ keepend containedin=@HTML
+hi def link LuaOrphanEnd	Statement
 if exists('s:current_syntax')
   let b:current_syntax=s:current_syntax
 else


### PR DESCRIPTION
Orphaned end statements `<% end %>` were causing error highlighting. I altered the region rule to include negative look arounds to exclude these. I added a new region for orphan ends specifically.